### PR TITLE
CHIRIMEN ブラウザー版との差異比較表変更

### DIFF
--- a/pizero/readme.md
+++ b/pizero/readme.md
@@ -566,10 +566,7 @@ CHIRIMEN for Raspberry Pi を利用するに際して、知っておくと良い
 | ライブラリ、ドライバーはhtmlで読み込む | jsの中で直接読み込む |
 | <pre>```<script src="polyfill.js"></script >```</pre> | <pre>```import {requestGPIOAccess} from "./node_modules/node-web-gpio/dist/index.js";```</pre><br><pre>```import {requestI2CAccess} from "./node_modules/node-web-i2c/index.js";```</pre> |
 |  <pre>```<script src="..../adt7410.js"></script >```</pre>   | <pre>```import ADT7410 from "@chirimen/adt7410";```</pre>  |
-
-|   | Sleep関数を宣言する  |
-| -- | -- |
-|   | <pre>```const sleep = msec => new Promise(resolve => setTimeout(resolve, msec));```</pre> |
+|   | Sleep関数を宣言する<br><pre>```const sleep = msec => new Promise(resolve => setTimeout(resolve, msec));```</pre> |
 
 # CHIRIMEN環境の任意のディレクトリへのセットアップ
 


### PR DESCRIPTION
## 変更前

| CHIRIMEN ブラウザー版       | Node.js                                                      |
| --------------------------- | ------------------------------------------------------------ |
| ライブラリ、ドライバーはhtmlで読み込む | jsの中で直接読み込む |
| <pre>```<script src="polyfill.js"></script >```</pre> | <pre>```import {requestGPIOAccess} from "./node_modules/node-web-gpio/dist/index.js";```</pre><br><pre>```import {requestI2CAccess} from "./node_modules/node-web-i2c/index.js";```</pre> |
|  <pre>```<script src="..../adt7410.js"></script >```</pre>   | <pre>```import ADT7410 from "@chirimen/adt7410";```</pre>  |

|   | Sleep関数を宣言する  |
| -- | -- |
|   | <pre>```const sleep = msec => new Promise(resolve => setTimeout(resolve, msec));```</pre> |

## 変更`後`

| CHIRIMEN ブラウザー版       | Node.js                                                      |
| --------------------------- | ------------------------------------------------------------ |
| ライブラリ、ドライバーはhtmlで読み込む | jsの中で直接読み込む |
| <pre>```<script src="polyfill.js"></script >```</pre> | <pre>```import {requestGPIOAccess} from "./node_modules/node-web-gpio/dist/index.js";```</pre><br><pre>```import {requestI2CAccess} from "./node_modules/node-web-i2c/index.js";```</pre> |
|  <pre>```<script src="..../adt7410.js"></script >```</pre>   | <pre>```import ADT7410 from "@chirimen/adt7410";```</pre>  |
|   | Sleep関数を宣言する<br><pre>```const sleep = msec => new Promise(resolve => setTimeout(resolve, msec));```</pre> |

